### PR TITLE
Fixed bug of not working arrow with settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,6 +50,8 @@ const BottomPanel = memo(() =>{
     }, []
   )
 
+  if (!showContent) {return null}
+
   if (settingsActive) {
     return (
       <Grid xs={12}>
@@ -57,7 +59,7 @@ const BottomPanel = memo(() =>{
       </Grid>
     )
   }
-  if (!showContent) {return null}
+  
   return (
     <>
       <Grid xs={4}>


### PR DESCRIPTION
The button for hiding content doesn't work with the settings menu because the return of the settings was before the return of null.